### PR TITLE
Removes hard coded file path when writing csv output

### DIFF
--- a/CarenotesParentDocumentFinder/App.config
+++ b/CarenotesParentDocumentFinder/App.config
@@ -6,6 +6,7 @@
   <appSettings>
     <add key="PageSize" value="100" />
     <add key="PatientIDFilePath" value="C:\drops\RandomPatientSample-Medium.csv" />
+    <add key="ProcessingResultsPath" value="C:\drops\ProcessingResults" />
     <add key="APIBaseURL" value="http://ahc-demo-cons.adastra.co.uk/api/integration/" />
     <add key="OutputFormat" value="Tabbed" />
     <add key="AttachmentsObjectTypeID" value ="10002024"/>

--- a/CarenotesParentDocumentFinder/EpisodeDocumentProcessor.cs
+++ b/CarenotesParentDocumentFinder/EpisodeDocumentProcessor.cs
@@ -4,6 +4,7 @@ using CsvHelper;
 using RestSharp;
 using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -265,13 +266,15 @@ namespace CarenotesParentDocumentFinder.DocumentProcessors
         {
             string filestringtime = DateTime.Now.Ticks.ToString();
 
-            using (var writer = new StreamWriter("C:\\drops\\parent-identifiers-" + filestringtime + ".csv"))
+            DirectoryInfo di = Directory.CreateDirectory(ConfigurationManager.AppSettings["ProcessingResultsPath"]);
+
+            using (var writer = new StreamWriter(di.FullName + "\\parent-identifiers-" + filestringtime + ".csv"))
             using (var csv = new CsvWriter(writer, CultureInfo.InvariantCulture))
             {
                 csv.WriteRecords(masterEpisodeList);
             }
 
-            Console.WriteLine($"Parent document identifiers written to: parent-identifiers-{filestringtime}.csv");
+            Console.WriteLine($"\nParent document identifiers written to: {0}\\parent-identifiers-{filestringtime}.csv", di.FullName);
         }
 
         protected virtual void Dispose(bool disposing)


### PR DESCRIPTION
Hard coded file path has been replaced by an app config specified value. An attempt to create the directory will be made if it doesn't exist.