### PR TITLE
Fixes AB#913 - Refactoring to resolve TD tight coupling

### DIFF
--- a/CarenotesParentDocumentFinder/APIClient.cs
+++ b/CarenotesParentDocumentFinder/APIClient.cs
@@ -1,4 +1,5 @@
 ﻿using CarenotesParentDocumentFinder.Data;
+using CarenotesParentDocumentFinder.Interfaces;
 using Newtonsoft.Json.Linq;
 using RestSharp;
 using System;
@@ -10,13 +11,13 @@ using static CarenotesParentDocumentFinder.Data.PicklistValues;
 
 namespace CarenotesParentDocumentFinder
 {
-    public static class ApiClient
+    public class ApiClient : IApiClient
     {
-        static string _apiSessionToken;
+        string _apiSessionToken;
 
-        static int _totalPages = -1;
+        int _totalPages = -1;
 
-        public static void GetSessionToken(RestClient apiClient)
+        public void GetSessionToken(RestClient apiClient)
         {
 
             Console.WriteLine();
@@ -40,7 +41,7 @@ namespace CarenotesParentDocumentFinder
             CheckResponseStatus(response);
         }
 
-        private static SecureString GetPassword()
+        private SecureString GetPassword()
         {
             Console.Write("Carenotes password: ");
 
@@ -76,7 +77,7 @@ namespace CarenotesParentDocumentFinder
             return securePassword;
         }
 
-        private static void CheckResponseStatus(RestResponse response)
+        private void CheckResponseStatus(RestResponse response)
         {
             if (response.IsSuccessful)
             {
@@ -97,7 +98,7 @@ namespace CarenotesParentDocumentFinder
             }
         }
 
-        public static bool ApiIsAvailable(RestClient apiClient)
+        public bool ApiIsAvailable(RestClient apiClient)
         {
 
             RestRequest request = new RestRequest("ping", Method.Get);
@@ -108,7 +109,7 @@ namespace CarenotesParentDocumentFinder
 
         }
 
-        public static List<ParentDocument> GetParentDocuments(RestClient apiClient, int patientId, int objectTypeId, int pageSize)
+        public List<ParentDocument> GetParentDocuments(RestClient apiClient, int patientId, int objectTypeId, int pageSize)
         {
             try
             {
@@ -167,7 +168,7 @@ namespace CarenotesParentDocumentFinder
             }
         }
 
-        private static List<ParentDocument> ParseParentDocumentJson(string responseContent, int patientId)
+        private List<ParentDocument> ParseParentDocumentJson(string responseContent, int patientId)
         {
 
             List<ParentDocument> parentDocuments = new List<ParentDocument>();
@@ -204,7 +205,7 @@ namespace CarenotesParentDocumentFinder
 
         }
 
-        public static List<CommunityEpisode> GetCommunityEpisodeDocuments(RestClient apiClient, int patientId, int pageSize)
+        public List<CommunityEpisode> GetCommunityEpisodeDocuments(RestClient apiClient, int patientId, int pageSize)
         {
             List<CommunityEpisode> communityEpisodes = new List<CommunityEpisode>();
 
@@ -253,7 +254,7 @@ namespace CarenotesParentDocumentFinder
             }
         }
 
-        private static List<CommunityEpisode> ParseCommunityEpisodeJson(string responseContent)
+        private List<CommunityEpisode> ParseCommunityEpisodeJson(string responseContent)
         {
 
             List<CommunityEpisode> communityEpisodes = new List<CommunityEpisode>();
@@ -288,7 +289,7 @@ namespace CarenotesParentDocumentFinder
 
         }
 
-        public static List<InpatientEpisode> GetInpatientEpisodeDocuments(RestClient apiClient, int patientId, int pageSize)
+        public List<InpatientEpisode> GetInpatientEpisodeDocuments(RestClient apiClient, int patientId, int pageSize)
         {
 
             List<InpatientEpisode> inpatientEpisodes = new List<InpatientEpisode>();
@@ -339,7 +340,7 @@ namespace CarenotesParentDocumentFinder
 
         }
 
-        private static List<InpatientEpisode> ParseInpatientEpisodeJson(string responseContent)
+        private List<InpatientEpisode> ParseInpatientEpisodeJson(string responseContent)
         {
             List<InpatientEpisode> inpatientEpisodes = new List<InpatientEpisode>();
 
@@ -373,7 +374,7 @@ namespace CarenotesParentDocumentFinder
 
         }
 
-        public static List<TeamEpisode> GetTeamEpisodeDocuments(RestClient apiClient, int patientId, int pageSize)
+        public List<TeamEpisode> GetTeamEpisodeDocuments(RestClient apiClient, int patientId, int pageSize)
         {
             List<TeamEpisode> inpatientEpisodes = new List<TeamEpisode>();
 
@@ -422,7 +423,7 @@ namespace CarenotesParentDocumentFinder
 
         }
 
-        private static List<TeamEpisode> ParseTeamEpisodeJson(string responseContent)
+        private List<TeamEpisode> ParseTeamEpisodeJson(string responseContent)
         {
             List<TeamEpisode> teamEpisode = new List<TeamEpisode>();
 
@@ -455,7 +456,7 @@ namespace CarenotesParentDocumentFinder
             return teamEpisode;
         }
 
-        public static bool SessionTokenExists()
+        public bool SessionTokenExists()
         {
             if (string.IsNullOrEmpty(_apiSessionToken))
                 return false;

--- a/CarenotesParentDocumentFinder/CarenotesParentDocumentFinder.csproj
+++ b/CarenotesParentDocumentFinder/CarenotesParentDocumentFinder.csproj
@@ -100,6 +100,9 @@
     <Compile Include="Data\PicklistValues.cs" />
     <Compile Include="Data\TeamEpisode.cs" />
     <Compile Include="EpisodeDocumentProcessor.cs" />
+    <Compile Include="Interfaces\IApiClient.cs" />
+    <Compile Include="Interfaces\ICommon.cs" />
+    <Compile Include="Interfaces\IEpisodeDocumentProcessor.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Helpers\ProgressBar.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/CarenotesParentDocumentFinder/Common.cs
+++ b/CarenotesParentDocumentFinder/Common.cs
@@ -1,4 +1,5 @@
 ﻿using CarenotesParentDocumentFinder.Data;
+using CarenotesParentDocumentFinder.Interfaces;
 using CsvHelper;
 using CsvHelper.Configuration;
 using RestSharp;
@@ -10,11 +11,11 @@ using System.IO;
 
 namespace CarenotesParentDocumentFinder
 {
-    public class Common
+    public class Common : ICommon
     {
         private readonly string _patientIDFilePath;
 
-        private readonly RestClient _apiClient;
+        private readonly RestClient _restClient;
 
         static readonly List<int> identifiers = new List<int>();
 
@@ -22,12 +23,15 @@ namespace CarenotesParentDocumentFinder
 
         private readonly int _pageSize;
 
-        public Common(string patientIDFilePath, RestClient restClient, int objectTypeID, int pageSize)
+        private readonly IApiClient _apiClient;
+
+        public Common(string patientIDFilePath, RestClient restClient, int objectTypeID, int pageSize, IApiClient apiClient)
         {
             this._patientIDFilePath = patientIDFilePath;
-            this._apiClient = restClient;
+            this._restClient = restClient;
             this._objectTypeID = objectTypeID;
             this._pageSize = pageSize;
+            this._apiClient = apiClient;
         }
 
         public List<int> GetPatientIdentifiersFromFile()
@@ -64,7 +68,7 @@ namespace CarenotesParentDocumentFinder
 
             List<ParentDocument> parentDocuments = new List<ParentDocument>();
 
-            parentDocuments.AddRange(ApiClient.GetParentDocuments(_apiClient, patientID, _objectTypeID, _pageSize));
+            parentDocuments.AddRange(_apiClient.GetParentDocuments(_restClient, patientID, _objectTypeID, _pageSize));
 
             return parentDocuments;
 

--- a/CarenotesParentDocumentFinder/EpisodeDocumentProcessor.cs
+++ b/CarenotesParentDocumentFinder/EpisodeDocumentProcessor.cs
@@ -1,5 +1,6 @@
 ﻿using CarenotesParentDocumentFinder.Data;
 using CarenotesParentDocumentFinder.Helpers;
+using CarenotesParentDocumentFinder.Interfaces;
 using CsvHelper;
 using RestSharp;
 using System;
@@ -13,23 +14,26 @@ using static CarenotesParentDocumentFinder.Data.PicklistValues;
 
 namespace CarenotesParentDocumentFinder.DocumentProcessors
 {
-    public class EpisodeDocumentProcessor : IDisposable
+    public class EpisodeDocumentProcessor : IEpisodeDocumentProcessor
     {
         readonly int _outputFormat;
         readonly int _pageSize;
         readonly List<Episode> masterEpisodeList = new List<Episode>();
-        private readonly RestClient _apiClient;
+        private readonly RestClient _restClient;
         readonly List<int> _identifiers;
         private bool disposedValue;
-        readonly private Common _common;
+        readonly private ICommon _common;
+        private readonly IApiClient _apiClient;
 
-        public EpisodeDocumentProcessor(RestClient restClient, int outputFormat, int pageSize, List<int> identifiers, Common common)
+
+        public EpisodeDocumentProcessor(RestClient restClient, int outputFormat, int pageSize, List<int> identifiers, ICommon common, IApiClient apiClient)
         {
-            this._apiClient = restClient;
+            this._restClient = restClient;
             this._outputFormat = outputFormat;
             this._pageSize = pageSize;
             this._identifiers = identifiers;
             this._common = common;
+            this._apiClient = apiClient;
         }
 
         public void ProcessParentDocumentEpisodes(List<int> patientIdentifiers)
@@ -91,22 +95,22 @@ namespace CarenotesParentDocumentFinder.DocumentProcessors
                 if (episodeId != null)
                 {
 
-                    communityEpisodes = ApiClient.GetCommunityEpisodeDocuments(_apiClient, patientId, _pageSize);
+                    communityEpisodes = _apiClient.GetCommunityEpisodeDocuments(_restClient, patientId, _pageSize);
 
                     mergedCommunityEpisodeData = (from c in communityEpisodes
-                                         join p in parentDocuments
-                                         on c.EpisodeID equals p.ContextualId
-                                         select new MergedEpisodeData
-                                         {
-                                             Contextual_ID = p.ContextualId,
-                                             Episode_ID = c.EpisodeID,
-                                             Episode_Location_ID = c.LocationID,
-                                             Episode_Location_Description = c.LocationDesc,
-                                             Parent_CN_Doc_ID = p.DocumentId,
-                                             Patient_ID = p.PatientID,
-                                             Service_ID = c.ServiceID,
-                                             Referral_ID = p.ReferralId
-                                         }).ToList<MergedEpisodeData>();
+                                                  join p in parentDocuments
+                                                  on c.EpisodeID equals p.ContextualId
+                                                  select new MergedEpisodeData
+                                                  {
+                                                      Contextual_ID = p.ContextualId,
+                                                      Episode_ID = c.EpisodeID,
+                                                      Episode_Location_ID = c.LocationID,
+                                                      Episode_Location_Description = c.LocationDesc,
+                                                      Parent_CN_Doc_ID = p.DocumentId,
+                                                      Patient_ID = p.PatientID,
+                                                      Service_ID = c.ServiceID,
+                                                      Referral_ID = p.ReferralId
+                                                  }).ToList<MergedEpisodeData>();
 
                 }
 
@@ -164,22 +168,22 @@ namespace CarenotesParentDocumentFinder.DocumentProcessors
                 if (episodeId != null)
                 {
 
-                    inpatientEpisodes = ApiClient.GetInpatientEpisodeDocuments(_apiClient, patientId, _pageSize);
+                    inpatientEpisodes = _apiClient.GetInpatientEpisodeDocuments(_restClient, patientId, _pageSize);
 
                     mergedInpatientEpisodeData = (from c in inpatientEpisodes
-                                         join p in parentDocuments
-                                         on c.EpisodeID equals p.ContextualId
-                                         select new MergedEpisodeData
-                                         {
-                                             Contextual_ID = p.ContextualId,
-                                             Episode_ID = c.EpisodeID,
-                                             Episode_Location_ID = c.LocationID,
-                                             Episode_Location_Description = c.LocationDesc,
-                                             Parent_CN_Doc_ID = p.DocumentId,
-                                             Patient_ID = p.PatientID,
-                                             Service_ID = c.ServiceID,
-                                             Referral_ID = p.ReferralId
-                                         }).ToList<MergedEpisodeData>();
+                                                  join p in parentDocuments
+                                                  on c.EpisodeID equals p.ContextualId
+                                                  select new MergedEpisodeData
+                                                  {
+                                                      Contextual_ID = p.ContextualId,
+                                                      Episode_ID = c.EpisodeID,
+                                                      Episode_Location_ID = c.LocationID,
+                                                      Episode_Location_Description = c.LocationDesc,
+                                                      Parent_CN_Doc_ID = p.DocumentId,
+                                                      Patient_ID = p.PatientID,
+                                                      Service_ID = c.ServiceID,
+                                                      Referral_ID = p.ReferralId
+                                                  }).ToList<MergedEpisodeData>();
 
                 }
 
@@ -236,22 +240,22 @@ namespace CarenotesParentDocumentFinder.DocumentProcessors
                 if (episodeId != null)
                 {
 
-                    teamEpisodes = ApiClient.GetTeamEpisodeDocuments(_apiClient, patientId, _pageSize);
+                    teamEpisodes = _apiClient.GetTeamEpisodeDocuments(_restClient, patientId, _pageSize);
 
                     mergedTeamEpisodeData = (from c in teamEpisodes
-                                         join p in parentDocuments
-                                         on c.EpisodeID equals p.ContextualId
-                                         select new MergedEpisodeData
-                                         {
-                                             Contextual_ID = p.ContextualId,
-                                             Episode_ID = c.EpisodeID,
-                                             Episode_Location_ID = c.LocationID,
-                                             Episode_Location_Description = c.LocationDesc,
-                                             Parent_CN_Doc_ID = p.DocumentId,
-                                             Patient_ID = p.PatientID,
-                                             Service_ID = c.ServiceID,
-                                             Referral_ID  = (int)p.ReferralId
-                                         }).ToList<MergedEpisodeData>();
+                                             join p in parentDocuments
+                                             on c.EpisodeID equals p.ContextualId
+                                             select new MergedEpisodeData
+                                             {
+                                                 Contextual_ID = p.ContextualId,
+                                                 Episode_ID = c.EpisodeID,
+                                                 Episode_Location_ID = c.LocationID,
+                                                 Episode_Location_Description = c.LocationDesc,
+                                                 Parent_CN_Doc_ID = p.DocumentId,
+                                                 Patient_ID = p.PatientID,
+                                                 Service_ID = c.ServiceID,
+                                                 Referral_ID = (int)p.ReferralId
+                                             }).ToList<MergedEpisodeData>();
 
                 }
 
@@ -311,7 +315,7 @@ namespace CarenotesParentDocumentFinder.DocumentProcessors
 
                 foreach (Episode episode in masterEpisodeList)
                 {
-                    Console.WriteLine($"{(EpisodeType)episode.EpisodeTypeID, -24}{episode.PatientID, -16}{episode.ReferralID, -16}{episode.EpisodeID, -16}{episode.LocationID, -16}{episode.LocationDesc, -40}{episode.CnDocID, -5}");
+                    Console.WriteLine($"{(EpisodeType)episode.EpisodeTypeID,-24}{episode.PatientID,-16}{episode.ReferralID,-16}{episode.EpisodeID,-16}{episode.LocationID,-16}{episode.LocationDesc,-40}{episode.CnDocID,-5}");
                 }
             }
 

--- a/CarenotesParentDocumentFinder/Interfaces/IApiClient.cs
+++ b/CarenotesParentDocumentFinder/Interfaces/IApiClient.cs
@@ -1,0 +1,17 @@
+﻿using CarenotesParentDocumentFinder.Data;
+using RestSharp;
+using System.Collections.Generic;
+
+namespace CarenotesParentDocumentFinder.Interfaces
+{
+    public interface IApiClient
+    {
+        bool ApiIsAvailable(RestClient apiClient);
+        List<CommunityEpisode> GetCommunityEpisodeDocuments(RestClient apiClient, int patientId, int pageSize);
+        List<InpatientEpisode> GetInpatientEpisodeDocuments(RestClient apiClient, int patientId, int pageSize);
+        List<ParentDocument> GetParentDocuments(RestClient apiClient, int patientId, int objectTypeId, int pageSize);
+        void GetSessionToken(RestClient apiClient);
+        List<TeamEpisode> GetTeamEpisodeDocuments(RestClient apiClient, int patientId, int pageSize);
+        bool SessionTokenExists();
+    }
+}

--- a/CarenotesParentDocumentFinder/Interfaces/ICommon.cs
+++ b/CarenotesParentDocumentFinder/Interfaces/ICommon.cs
@@ -1,0 +1,12 @@
+﻿using CarenotesParentDocumentFinder.Data;
+using System.Collections.Generic;
+
+namespace CarenotesParentDocumentFinder.Interfaces
+{
+    public interface ICommon
+    {
+        int GetObjectTypeID();
+        List<ParentDocument> GetParentDocuments(int patientID);
+        List<int> GetPatientIdentifiersFromFile();
+    }
+}

--- a/CarenotesParentDocumentFinder/Interfaces/IEpisodeDocumentProcessor.cs
+++ b/CarenotesParentDocumentFinder/Interfaces/IEpisodeDocumentProcessor.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace CarenotesParentDocumentFinder.Interfaces
+{
+    public interface IEpisodeDocumentProcessor : IDisposable
+    {
+        void ProcessParentDocumentEpisodes(List<int> patientIdentifiers);
+    }
+}

--- a/TestProject/MockApi.cs
+++ b/TestProject/MockApi.cs
@@ -1,0 +1,118 @@
+﻿using CarenotesParentDocumentFinder.Data;
+using CarenotesParentDocumentFinder.Interfaces;
+using System;
+using System.Collections.Generic;
+
+namespace TestProject
+{
+    internal class MockApi : IApiClient
+    {
+        readonly bool _flaky = false;
+        readonly bool _unavailable = false;
+
+        public MockApi(bool flaky = false, bool unavailable = false)
+        {
+            _flaky = flaky;
+            _unavailable = unavailable;
+        }
+
+
+        public bool ApiIsAvailable(RestSharp.RestClient apiClient)
+        {
+
+            if (_unavailable) return false;
+
+            if (_flaky)
+            {
+                Random rnd = new Random();
+                return rnd.NextDouble() > 0.5;
+            }
+
+            return true;
+        }
+
+        public List<CommunityEpisode> GetCommunityEpisodeDocuments(RestSharp.RestClient apiClient, int patientId, int pageSize)
+        {
+            if (_unavailable) return null;
+
+            if (_flaky)
+            {
+                Random rnd = new Random();
+                bool state = rnd.NextDouble() > 0.5;
+
+                if (state) return new List<CommunityEpisode>();
+                else return null;
+            }
+
+
+            return new List<CommunityEpisode>();
+        }
+
+        public List<InpatientEpisode> GetInpatientEpisodeDocuments(RestSharp.RestClient apiClient, int patientId, int pageSize)
+        {
+            if (_unavailable) return null;
+
+            if (_flaky)
+            {
+                Random rnd = new Random();
+                bool state = rnd.NextDouble() > 0.5;
+
+                if (state) return new List<InpatientEpisode>();
+                else return null;
+            }
+
+            return new List<InpatientEpisode>();
+        }
+
+        public List<ParentDocument> GetParentDocuments(RestSharp.RestClient apiClient, int patientId, int objectTypeId, int pageSize)
+        {
+            if (_unavailable) return null;
+
+            if (_flaky)
+            {
+                Random rnd = new Random();
+                bool state = rnd.NextDouble() > 0.5;
+
+                if (state) return new List<ParentDocument>();
+                else return null;
+            }
+
+            return new List<ParentDocument>();
+        }
+
+        public void GetSessionToken(RestSharp.RestClient apiClient)
+        {
+            // Method intentionally left empty.
+        }
+
+        public List<TeamEpisode> GetTeamEpisodeDocuments(RestSharp.RestClient apiClient, int patientId, int pageSize)
+        {
+            if (_unavailable) return null;
+
+            if (_flaky)
+            {
+                Random rnd = new Random();
+                bool state = rnd.NextDouble() > 0.5;
+
+                if (state) return new List<TeamEpisode>();
+                else return null;
+            }
+
+            return new List<TeamEpisode>();
+        }
+
+        public bool SessionTokenExists()
+        {
+            if (_unavailable) return false;
+
+            if (_flaky)
+            {
+                Random rnd = new Random();
+                return rnd.NextDouble() > 0.5;
+            }
+
+            return true;
+
+        }
+    }
+}

--- a/TestProject/MockCommon.cs
+++ b/TestProject/MockCommon.cs
@@ -1,0 +1,31 @@
+﻿using CarenotesParentDocumentFinder;
+using CarenotesParentDocumentFinder.Data;
+using System;
+using System.Collections.Generic;
+
+namespace TestProject
+{
+    internal class MockCommon : ICommon
+    {
+        public int GetObjectTypeID()
+        {
+            Random rnd = new Random();
+            return rnd.Next();
+        }
+
+        public List<ParentDocument> GetParentDocuments(int patientID)
+        {
+            return new List<ParentDocument>()
+            {
+                new ParentDocument()
+                {
+                    Active = true, ContextualId = 0, DocumentId = 0, DocumentSummary = "", DocumentTypeDescription = "", DocumentTypeID = 0, EpisodeId = 0, PatientID = 0, ReferralId = 0
+                }};
+        }
+
+        public List<int> GetPatientIdentifiersFromFile()
+        {
+            return new List<int>() { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        }
+    }
+}

--- a/TestProject/TestProject.csproj
+++ b/TestProject/TestProject.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CarenotesParentDocumentFinder\CarenotesParentDocumentFinder.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TestProject/UnitTest1.cs
+++ b/TestProject/UnitTest1.cs
@@ -1,0 +1,35 @@
+using CarenotesParentDocumentFinder.Data;
+using CarenotesParentDocumentFinder.DocumentProcessors;
+using CarenotesParentDocumentFinder.Interfaces;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace TestProject
+{
+    public class DataObjectTests
+    {
+
+        [Test]
+        public void CanInitialiseEpisode()
+        {
+            Episode testEpisode = new Episode() { CnDocID = 1234, EpisodeID = 1, EpisodeTypeID = 1, LocationDesc = "Location A", LocationID = 1, PatientID = 122, ReferralID = 1, ReferralStatusID = 0, ServiceID = 1 };
+            
+            Assert.NotNull(testEpisode);
+            
+            Assert.Pass();
+        }
+
+        public void CanRequestInpatientEpisode()
+        {
+            IApiClient mockClient = new MockApi();
+
+            IMockCommon
+
+            List<int> mockIdentifiers = new List<int>();
+
+            EpisodeDocumentProcessor episodeDocumentProcessor = new EpisodeDocumentProcessor(mockClient, 1, 100, mockIdentifiers, 
+        }
+
+
+    }
+}


### PR DESCRIPTION
Adds interfaces to implement loosely coupled dependencies. Refactors classes to share the same instance of APIClient instead of calling statically typed class. Fixes [AB#913](https://dev.azure.com/zerozeroforty/279fc295-6325-405e-b88f-289be095d2b5/_workitems/edit/913)